### PR TITLE
Auto-rotate teams and track rounds per team

### DIFF
--- a/style.css
+++ b/style.css
@@ -193,6 +193,7 @@ main {
 .team .name { font-weight: 700; }
 .team .score { font-weight: 800; font-size: 22px; align-self: center; }
 .team .controls { grid-column: 1 / span 2; display: flex; gap: 6px; }
+.team .rounds { grid-column: 1 / span 2; font-size: 12px; color: var(--muted); }
 
 .timer {
   display: flex;


### PR DESCRIPTION
## Summary
- Track how many rounds each team has played and show the count on the scoreboard
- Prevent changing the active team during a round and disable the next-team button
- Automatically advance to the next team after each round

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ece3f0a04832bbca91bffca2974f9