### PR TITLE
Fix invisible timer text on dark bar

### DIFF
--- a/script.js
+++ b/script.js
@@ -377,6 +377,7 @@
     btnPass.disabled = false;
     btnCorrect.disabled = false;
     btnNextTeam.disabled = true;
+    $('#timerBar').style.color = '#fff';
     tickTimer();
     round.timerId = setInterval(tickTimer, 100);
   }
@@ -426,6 +427,7 @@
     btnStart.disabled=false; btnPause.disabled=true; btnEnd.disabled=true; btnPass.disabled=true; btnCorrect.disabled=true; btnNextTeam.disabled=false;
     timeRemain.textContent = String(state.settings.roundSeconds);
     $('#timerBar').style.background='';
+    $('#timerBar').style.color='';
 
     if(timeup){
       beep();


### PR DESCRIPTION
## Summary
- Ensure timer's text color switches to white while countdown runs, so it stays visible against a dark background
- Reset timer text color when the round ends

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed6a85d00832b8311fc0cc01012e5