### PR TITLE
Fix timer color change on round start

### DIFF
--- a/script.js
+++ b/script.js
@@ -421,7 +421,6 @@
     btnPass.disabled = false;
     btnCorrect.disabled = false;
     btnNextTeam.disabled = true;
-    $('#timerBar').style.color = '#fff';
     tickTimer();
     round.timerId = setInterval(tickTimer, 100);
   }


### PR DESCRIPTION
## Summary
- Remove hardcoded white color from timer when round starts so it keeps theme text color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689edabc0530832baee9a102e87951d1