### PR TITLE
Adjust word display to shrink text instead of expanding container

### DIFF
--- a/script.js
+++ b/script.js
@@ -476,6 +476,21 @@
   const btnNextTeam = $('#btnNextTeam');
   const roundSecondsInput = $('#roundSeconds');
 
+  function fitBigWord(){
+    bigWord.style.fontSize = '';
+    const container = bigWord.parentElement;
+    const style = getComputedStyle(container);
+    const padding = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+    const maxWidth = container.clientWidth - padding;
+    let size = parseFloat(getComputedStyle(bigWord).fontSize);
+    while(bigWord.scrollWidth > maxWidth && size > 16){
+      size -= 2;
+      bigWord.style.fontSize = size + 'px';
+    }
+  }
+
+  window.addEventListener('resize', fitBigWord);
+
   let round = {
     running:false,
     paused:false,
@@ -501,10 +516,12 @@
   function pickNextWord(){
     if(round.words.length===0){
       bigWord.textContent = '제시어가 없습니다 (카테고리 수정 필요)';
+      fitBigWord();
       return;
     }
     round.wordIndex = (round.wordIndex+1) % round.words.length;
     bigWord.textContent = round.words[round.wordIndex];
+    fitBigWord();
   }
 
   function startRound(){

--- a/style.css
+++ b/style.css
@@ -235,6 +235,7 @@ main {
   letter-spacing: 1px;
   line-height: 1.15;
   word-break: keep-all;
+  white-space: nowrap;
 }
 
 .actions-grid {


### PR DESCRIPTION
## Summary
- Prevent word container from resizing by keeping text on a single line
- Dynamically shrink displayed word font size to fit within its container, updating on resize and word changes

## Testing
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f17e94a3c832b90c99d9e906edf4b