### PR TITLE
fix: keep word container fixed

### DIFF
--- a/style.css
+++ b/style.css
@@ -227,6 +227,7 @@ main {
   border: 1px dashed var(--border);
   border-radius: 16px;
   padding: 16px;
+  height: 120px; /* keep container fixed regardless of word font size */
 }
 
 .word .bigword {


### PR DESCRIPTION
## Summary
- Fix word container height so it stays stationary when answer font size changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f193c3304832b8a25b071828c7d1d