### PR TITLE
fix: prevent word container resizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -218,7 +218,7 @@ main {
 }
 
 .word {
-  flex: 1;
+  flex: none; /* prevent container from expanding/shrinking with font size */
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- prevent word container from expanding or shrinking when the displayed word's font size changes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f1ab9bb78832baf2e1e3bcdb0d1a4