### PR TITLE
Add reset controls to category tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
   <section id="catScreen" class="screen panel">
     <h2>카테고리</h2>
     <div id="catList" class="categories"></div>
+    <div class="row">
+      <button id="btnResetScores" class="ghost" title="모든 팀 점수를 초기화">점수 리셋</button>
+      <button id="btnResetCats" class="ghost" title="사용된 카테고리 초기화">카테고리 리셋</button>
+    </div>
     <div class="hint">라운드 시작 시 하나의 카테고리를 선택하세요.</div>
   </section>
 
@@ -82,7 +86,6 @@
       <label><input type="checkbox" id="toggleBlockOnEnd" checked> 라운드 종료 시 선택 카테고리 막기</label>
       <div class="row">
         <button id="btnEditCats" class="ghost" title="카테고리 편집">카테고리 편집</button>
-        <button id="btnResetCats" class="ghost" title="사용된 카테고리 초기화">카테고리 리셋</button>
       </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -397,6 +397,15 @@
     renderCategories();
   }
 
+  function resetScores(){
+    state.teams.forEach(t=>{
+      t.score = 0;
+      t.rounds = 0;
+    });
+    saveState();
+    renderTeams();
+  }
+
   // ----- 팀 & 점수 -----
   const board = $('#scoreboard');
   function addTeam(name){
@@ -806,6 +815,10 @@
 
   $('#btnResetCats').addEventListener('click', ()=>{
     if(confirm('사용된 카테고리 표시를 모두 해제할까요?')) resetUsedCategories();
+  });
+
+  $('#btnResetScores').addEventListener('click', ()=>{
+    if(confirm('모든 팀 점수를 초기화할까요?')) resetScores();
   });
 
   $('#btnHardReset').addEventListener('click', ()=>{


### PR DESCRIPTION
## Summary
- add score reset and category reset buttons to category tab for quick access
- implement resetScores function to clear team scores and rounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd936b0b0832b833cb1b890e4762c