### PR TITLE
feat: add responsive layout for mobile and desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -346,7 +346,16 @@ dialog::backdrop { background: rgba(0,0,0,.6); }
 .screen { display: flex; flex-direction: column; gap: 14px; }
 .section { display: flex; flex-direction: column; gap: 8px; }
 
+/* Desktop-specific tweaks */
+@media (min-width: 981px) {
+  header { padding: 16px 24px; }
+}
+
+/* Mobile-specific tweaks */
 @media (max-width: 600px) {
   body { font-size: 14px; }
+  header { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .actions-grid { grid-template-columns: 1fr; }
   .timer .big { font-size: 40px; }
+  .timer .row { flex-direction: column; align-items: stretch; }
 }


### PR DESCRIPTION
## Summary
- improve styling for desktop by increasing header padding on wide screens
- optimize mobile layout: stack header elements, single-column action buttons, and better timer layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe144a97c832baa677cb834f6e6e7