### PR TITLE
Add team import/export

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,11 @@
       <label title="정답 버튼을 누르면 해당 팀 점수를 자동으로 +1 합니다.">
         <input type="checkbox" id="toggleAutoScore" checked> 정답 시 자동 가점(+1)
       </label>
+      <div class="row">
+        <span class="spacer"></span>
+        <button id="btnTeamsExport" class="ghost">내보내기</button>
+        <button id="btnTeamsImport" class="ghost">가져오기</button>
+      </div>
     </div>
 
     <div class="section">

--- a/script.js
+++ b/script.js
@@ -825,6 +825,45 @@
     inp.click();
   }
 
+  function exportTeams(){
+    const data = state.teams.map(t=>({name:t.name, score:t.score, rounds:t.rounds}));
+    const blob = new Blob([JSON.stringify(data,null,2)],{type:'application/json;charset=utf-8'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'speedquiz_teams.json'; a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function importTeams(){
+    const inp = document.createElement('input');
+    inp.type = 'file'; inp.accept = '.json,application/json';
+    inp.addEventListener('change', ()=>{
+      const f = inp.files?.[0];
+      if(!f) return;
+      const r = new FileReader();
+      r.onload = ()=>{
+        try{
+          const arr = JSON.parse(String(r.result||''));
+          if(!Array.isArray(arr)) throw new Error('팀 배열이 아닙니다.');
+          state.teams = arr.map(t=>({
+            id: uid('team'),
+            name: String(t.name||''),
+            score: Number(t.score)||0,
+            rounds: Number(t.rounds)||0
+          }));
+          state.activeTeamId = state.teams[0]?.id || null;
+          saveState();
+          renderTeams();
+          alert('팀 데이터를 불러왔습니다.');
+        }catch(e){
+          alert('불러오기 실패: ' + e.message);
+        }
+      };
+      r.readAsText(f,'utf-8');
+    });
+    inp.click();
+  }
+
   // ----- 전체화면 -----
   function toggleFullscreen(){
     if(!document.fullscreenElement){
@@ -901,6 +940,8 @@
   $('#btnCatsCancel').addEventListener('click', ()=>$('#dlgCats').close());
   $('#btnCatsExport').addEventListener('click', exportCats);
   $('#btnCatsImport').addEventListener('click', importCats);
+  $('#btnTeamsExport').addEventListener('click', exportTeams);
+  $('#btnTeamsImport').addEventListener('click', importTeams);
 
   $('#btnSummaryOk').addEventListener('click', ()=>$('#dlgSummary').close());
 


### PR DESCRIPTION
## Summary
- add export/import buttons for team management
- support exporting and importing team data with scores via JSON

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689ff7b66aa8832b99599f46d7438bb2