### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
 
     <div class="section">
       <h3>기타</h3>
+      <label><input type="checkbox" id="toggleDarkMode"> 다크 모드</label>
       <button id="btnFull" class="ghost" title="전체화면 전환">전체화면</button>
       <button id="btnHardReset" class="danger" title="모든 데이터 초기화">전체 초기화</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -362,6 +362,9 @@
         if(state.settings && typeof state.settings.autoScoreOnCorrect === 'undefined'){
           state.settings.autoScoreOnCorrect = true;
         }
+        if(state.settings && typeof state.settings.darkMode === 'undefined'){
+          state.settings.darkMode = false;
+        }
         // ensure rounds property exists for teams loaded from older state
         state.teams?.forEach(t=>{ if(typeof t.rounds !== 'number') t.rounds = 0; });
         return;
@@ -372,7 +375,7 @@
       activeTeamId: null,
       categories: DEFAULT_CATEGORIES.map(c=>({id:uid('cat'), name:c.name, words:[...c.words]})),
       usedCategoryIds: [],
-      settings: { roundSeconds:60, blockUsedCategoryOnEnd:true, hideUsedCategories:false, autoScoreOnCorrect:true },
+      settings: { roundSeconds:60, blockUsedCategoryOnEnd:true, hideUsedCategories:false, autoScoreOnCorrect:true, darkMode:false },
       version: 2
     };
     saveState();
@@ -834,6 +837,10 @@
     }
   }
 
+  function applyTheme(){
+    document.documentElement.classList.toggle('dark', state.settings.darkMode);
+  }
+
   // ----- 이벤트 바인딩 -----
   $('#btnAddTeam').addEventListener('click', ()=>{
     const name = $('#newTeamName').value.trim();
@@ -880,6 +887,10 @@
     state.settings.autoScoreOnCorrect = e.target.checked; saveState();
   });
 
+  $('#toggleDarkMode').addEventListener('change', (e)=>{
+    state.settings.darkMode = e.target.checked; saveState(); applyTheme();
+  });
+
   $('#btnResetCats').addEventListener('click', ()=>{
     if(confirm('사용된 카테고리 표시를 모두 해제할까요?')) resetUsedCategories();
   });
@@ -911,9 +922,11 @@
     $('#toggleHideUsed').checked = state.settings.hideUsedCategories;
     $('#toggleBlockOnEnd').checked = state.settings.blockUsedCategoryOnEnd;
     $('#toggleAutoScore').checked = state.settings.autoScoreOnCorrect;
+    $('#toggleDarkMode').checked = state.settings.darkMode;
     roundSecondsInput.value = String(state.settings.roundSeconds);
     timeRemain.textContent = String(state.settings.roundSeconds);
     updateStartBtnState();
+    applyTheme();
   }
 
   loadState();

--- a/style.css
+++ b/style.css
@@ -11,6 +11,35 @@
   --shadow: 0 2px 6px rgba(0,0,0,.06);
   --scrollbar-thumb: rgba(0,0,0,.3);
   --scrollbar-track: rgba(0,0,0,.08);
+
+  /* dark theme palette */
+  --bg-dark: #1e1f23;
+  --panel-dark: #2a2b30;
+  --accent-dark: #4b8bf4;
+  --accent-2-dark: #4caf50;
+  --muted-dark: #adb5bd;
+  --text-dark: #f8f9fa;
+  --danger-dark: #dc3545;
+  --warn-dark: #ffc107;
+  --border-dark: #3a3b3f;
+  --shadow-dark: 0 2px 6px rgba(0,0,0,.5);
+  --scrollbar-thumb-dark: rgba(255,255,255,.3);
+  --scrollbar-track-dark: rgba(255,255,255,.08);
+}
+
+:root.dark {
+  --bg: var(--bg-dark);
+  --panel: var(--panel-dark);
+  --accent: var(--accent-dark);
+  --accent-2: var(--accent-2-dark);
+  --muted: var(--muted-dark);
+  --text: var(--text-dark);
+  --danger: var(--danger-dark);
+  --warn: var(--warn-dark);
+  --border: var(--border-dark);
+  --shadow: var(--shadow-dark);
+  --scrollbar-thumb: var(--scrollbar-thumb-dark);
+  --scrollbar-track: var(--scrollbar-track-dark);
 }
 
 * {


### PR DESCRIPTION
## Summary
- add CSS variables for a dark theme palette
- provide settings toggle to switch between light and dark modes
- persist theme choice and apply by toggling document class

## Testing
- `npm test` *(fails: ENOENT, missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ff7b7d9c8832baf57eb4638b0dbbe