### PR TITLE
Fix missing comma in round state object

### DIFF
--- a/script.js
+++ b/script.js
@@ -596,7 +596,7 @@
     pass:0,
     correctWords:[],
     passedWords:[],
-    lastWarnSec:null
+    lastWarnSec:null,
     actionStack:[]
   };
 


### PR DESCRIPTION
## Summary
- Add missing comma between `lastWarnSec` and `actionStack` in round state initialization

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689ffccce734832b9f999cb8b1d9b081