### PR TITLE
Fix search input text visibility in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -125,12 +125,16 @@ button.danger { background: var(--danger); color: #fff; border-color: var(--dang
 button.ghost { background: transparent; }
 
 input[type="text"], input[type="number"] {
-  background: #fff;
+  background: var(--panel);
   border: 1px solid var(--border);
   color: var(--text);
   padding: 10px 12px;
   border-radius: 10px;
   width: 100%;
+}
+
+input::placeholder {
+  color: var(--muted);
 }
 
 label { font-size: 13px; color: var(--muted); }


### PR DESCRIPTION
## Summary
- Ensure inputs match theme colors in light and dark mode by using CSS variables
- Style input placeholders with theme-aware muted color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ffff7a3d8832bb2a8ead98f4672c3