### PR TITLE
Fix manual score buttons not working

### DIFF
--- a/script.js
+++ b/script.js
@@ -399,7 +399,7 @@
       if(k==='class') e.className = v;
       else if(k==='dataset') { for (const [dk,dv] of Object.entries(v)) e.dataset[dk]=dv; }
       else if(k==='html') e.innerHTML = v;
-      else if(k.startsWith('on') && typeof v === 'function') e.addEventListener(k.slice(2), v);
+      else if(k.startsWith('on') && typeof v === 'function') e.addEventListener(k.slice(2).toLowerCase(), v);
       else e.setAttribute(k, v);
     }
     for(const c of children){


### PR DESCRIPTION
## Summary
- Ensure event names are lowercased in helper function so buttons using `onClick` handlers work

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a01cd628a0832b930930395de2d0b1