### PR TITLE
라운드 안내 문구가 영역을 벗어나지 않도록 수정

### DIFF
--- a/style.css
+++ b/style.css
@@ -260,7 +260,7 @@ main {
   border: 1px dashed var(--border);
   border-radius: 16px;
   padding: 16px;
-  height: 120px; /* keep container fixed regardless of word font size */
+  min-height: 120px; /* ensure space but allow multi-line words */
 }
 
 .word .bigword {
@@ -269,7 +269,7 @@ main {
   letter-spacing: 1px;
   line-height: 1.15;
   word-break: keep-all;
-  white-space: nowrap;
+  white-space: normal; /* allow wrapping within the container */
 }
 
 .actions-grid {


### PR DESCRIPTION
## Summary
- allow word container to grow and wrap text

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a020508240832ba03e2e0bdc4f0a59