### PR TITLE
Reset word prompt after round end

### DIFF
--- a/script.js
+++ b/script.js
@@ -712,6 +712,8 @@
     timeRemain.textContent = String(state.settings.roundSeconds);
     $('#timerBar').style.background='';
     $('#timerBar').style.color='';
+    bigWord.textContent = '라운드를 시작하세요';
+    fitBigWord();
 
     if(timeup){
       beep();


### PR DESCRIPTION
## Summary
- Reset the displayed prompt to "라운드를 시작하세요" whenever a round ends

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a14d2d4868832b9cc58902b72428b8