### PR TITLE
Add pre-round countdown

### DIFF
--- a/script.js
+++ b/script.js
@@ -632,7 +632,6 @@
     const cat = state.categories.find(c=>c.id===round.categoryId);
     round.words = shuffle([...cat.words]);
     round.wordIndex = -1;
-    pickNextWord();
     round.correct = 0; round.pass = 0;
     round.correctWords = [];
     round.passedWords = [];
@@ -644,17 +643,40 @@
     state.settings.roundSeconds = secs;
     saveState();
 
+    btnStart.disabled = true;
+    btnPause.disabled = true;
+    btnEnd.disabled = true;
+    btnPass.disabled = true;
+    btnCorrect.disabled = true;
+    btnUndo.disabled = true;
+    btnNextTeam.disabled = true;
+
+    let count = 3;
+    const countdown = ()=>{
+      if(count>0){
+        bigWord.textContent = String(count);
+        fitBigWord();
+        beep(600);
+        count--;
+        setTimeout(countdown, 1000);
+      }else{
+        beginRound(secs);
+      }
+    };
+    countdown();
+  }
+
+  function beginRound(secs){
+    pickNextWord();
     round.running = true; round.paused = false;
     round.startAt = Date.now();
     round.endAt = round.startAt + secs*1000;
     round.leftMs = secs*1000;
-    btnStart.disabled = true;
     btnPause.disabled = false;
     btnEnd.disabled = false;
     btnPass.disabled = false;
     btnCorrect.disabled = false;
     btnUndo.disabled = true;
-    btnNextTeam.disabled = true;
     tickTimer();
     round.timerId = setInterval(tickTimer, 100);
   }


### PR DESCRIPTION
## Summary
- Add 3-2-1 pre-countdown when starting a round
- Disable controls during countdown and begin round automatically afterward

## Testing
- `node --check script.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a169456f5c832b84e4c624d1057353