### PR TITLE
feat: add combo bonus option

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,9 @@
       <label title="정답 버튼을 누르면 해당 팀 점수를 자동으로 +1 합니다.">
         <input type="checkbox" id="toggleAutoScore" checked> 정답 시 자동 가점(+1)
       </label>
+      <label title="3연속 정답 시 추가 +2점 보너스를 적용합니다.">
+        <input type="checkbox" id="toggleComboBonus"> 3연속 정답 보너스(+2)
+      </label>
       <div class="row">
         <span class="spacer"></span>
         <button id="btnTeamsExport" class="ghost">내보내기</button>

--- a/script.js
+++ b/script.js
@@ -344,7 +344,7 @@
     activeTeamId: string|null,
     categories: {id:string,name:string,words:string[]}[],
     usedCategoryIds: string[],
-    settings: { roundSeconds:number, blockUsedCategoryOnEnd:boolean, hideUsedCategories:boolean, autoScoreOnCorrect:boolean },
+    settings: { roundSeconds:number, blockUsedCategoryOnEnd:boolean, hideUsedCategories:boolean, autoScoreOnCorrect:boolean, darkMode:boolean, comboBonus:boolean },
     version:number
   }} */
   let state;
@@ -365,6 +365,9 @@
         if(state.settings && typeof state.settings.darkMode === 'undefined'){
           state.settings.darkMode = false;
         }
+        if(state.settings && typeof state.settings.comboBonus === 'undefined'){
+          state.settings.comboBonus = false;
+        }
         // ensure rounds property exists for teams loaded from older state
         state.teams?.forEach(t=>{ if(typeof t.rounds !== 'number') t.rounds = 0; });
         return;
@@ -375,8 +378,8 @@
       activeTeamId: null,
       categories: DEFAULT_CATEGORIES.map(c=>({id:uid('cat'), name:c.name, words:[...c.words]})),
       usedCategoryIds: [],
-      settings: { roundSeconds:60, blockUsedCategoryOnEnd:true, hideUsedCategories:false, autoScoreOnCorrect:true, darkMode:false },
-      version: 2
+      settings: { roundSeconds:60, blockUsedCategoryOnEnd:true, hideUsedCategories:false, autoScoreOnCorrect:true, darkMode:false, comboBonus:false },
+      version: 3
     };
     saveState();
   }
@@ -597,7 +600,8 @@
     correctWords:[],
     passedWords:[],
     lastWarnSec:null,
-    actionStack:[]
+    actionStack:[],
+    correctStreak:0
   };
 
   function updateStartBtnState(){
@@ -633,7 +637,7 @@
     round.words = shuffle([...cat.words]);
     round.wordIndex = -1;
     pickNextWord();
-    round.correct = 0; round.pass = 0;
+    round.correct = 0; round.pass = 0; round.correctStreak = 0;
     round.correctWords = [];
     round.passedWords = [];
     round.lastWarnSec = null;
@@ -754,12 +758,15 @@
     if(act.type==='pass'){
       if(round.pass>0) round.pass--;
       if(round.passedWords.length>0) round.passedWords.pop();
+      round.correctStreak = act.prevStreak || 0;
     }else if(act.type==='correct'){
       if(round.correct>0) round.correct--;
       if(round.correctWords.length>0) round.correctWords.pop();
       if(state.activeTeamId && state.settings.autoScoreOnCorrect){
         incScore(state.activeTeamId, -1);
+        if(act.bonus) incScore(state.activeTeamId, -2);
       }
+      round.correctStreak = act.prevStreak || 0;
     }
     round.wordIndex = act.index;
     bigWord.textContent = act.word;
@@ -771,10 +778,12 @@
     if(!round.running || round.paused) return;
     const w = round.words[round.wordIndex];
     const idx = round.wordIndex;
+    const prevStreak = round.correctStreak;
     round.pass++;
     if(w) round.passedWords.push(w);
+    round.correctStreak = 0;
     beep(440);
-    round.actionStack.push({type:'pass', word:w, index:idx});
+    round.actionStack.push({type:'pass', word:w, index:idx, prevStreak});
     updateUndoState();
     afterAnswer();
   }
@@ -782,11 +791,20 @@
     if(!round.running || round.paused) return;
     const w = round.words[round.wordIndex];
     const idx = round.wordIndex;
+    const prevStreak = round.correctStreak;
     round.correct++;
+    round.correctStreak++;
     if(w) round.correctWords.push(w);
-    if(state.activeTeamId && state.settings.autoScoreOnCorrect) incScore(state.activeTeamId, +1);
+    let bonus = false;
+    if(state.activeTeamId && state.settings.autoScoreOnCorrect){
+      incScore(state.activeTeamId, +1);
+      if(state.settings.comboBonus && round.correctStreak % 3 === 0){
+        incScore(state.activeTeamId, +2);
+        bonus = true;
+      }
+    }
     beep(1200);
-    round.actionStack.push({type:'correct', word:w, index:idx});
+    round.actionStack.push({type:'correct', word:w, index:idx, prevStreak, bonus});
     updateUndoState();
     afterAnswer();
   }
@@ -991,6 +1009,9 @@
   $('#toggleAutoScore').addEventListener('change', (e)=>{
     state.settings.autoScoreOnCorrect = e.target.checked; saveState();
   });
+  $('#toggleComboBonus').addEventListener('change', (e)=>{
+    state.settings.comboBonus = e.target.checked; saveState();
+  });
 
   $('#toggleDarkMode').addEventListener('change', (e)=>{
     state.settings.darkMode = e.target.checked; saveState(); applyTheme();
@@ -1029,6 +1050,7 @@
     $('#toggleHideUsed').checked = state.settings.hideUsedCategories;
     $('#toggleBlockOnEnd').checked = state.settings.blockUsedCategoryOnEnd;
     $('#toggleAutoScore').checked = state.settings.autoScoreOnCorrect;
+    $('#toggleComboBonus').checked = state.settings.comboBonus;
     $('#toggleDarkMode').checked = state.settings.darkMode;
     roundSecondsInput.value = String(state.settings.roundSeconds);
     timeRemain.textContent = String(state.settings.roundSeconds);


### PR DESCRIPTION
## Summary
- add optional 3-answer combo bonus toggle in settings
- track correct-answer streaks and award +2 bonus for every third correct answer
- maintain streak and bonus through undo operations

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a169645890832b963ee14644fe595f