### PR TITLE
Reset current category display after game ends

### DIFF
--- a/script.js
+++ b/script.js
@@ -783,8 +783,6 @@
     if(state.settings.blockUsedCategoryOnEnd && round.categoryId){
       if(!state.usedCategoryIds.includes(round.categoryId)){
         state.usedCategoryIds.push(round.categoryId);
-        saveState();
-        renderCategories();
       }
     }
     // increment round count for current team
@@ -795,6 +793,10 @@
     saveState();
     showSummary(timeup);
     nextTeam();
+    selectedCategoryId = null;
+    renderCategories();
+    updateStartBtnState();
+    updateCurrentCategory();
     showScreen('catScreen');
   }
 


### PR DESCRIPTION
## Summary
- Clear selected category and update UI when a round ends
- Refresh category list and start button state after round completion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a174e8f644832ba78bc6edf8bb427b