### PR TITLE
Fix big word area and text fitting

### DIFF
--- a/script.js
+++ b/script.js
@@ -595,10 +595,12 @@
     bigWord.style.fontSize = '';
     const container = bigWord.parentElement;
     const style = getComputedStyle(container);
-    const padding = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
-    const maxWidth = container.clientWidth - padding;
+    const paddingX = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+    const paddingY = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+    const maxWidth = container.clientWidth - paddingX;
+    const maxHeight = container.clientHeight - paddingY;
     let size = parseFloat(getComputedStyle(bigWord).fontSize);
-    while(bigWord.scrollWidth > maxWidth && size > 16){
+    while((bigWord.scrollWidth > maxWidth || bigWord.scrollHeight > maxHeight) && size > 16){
       size -= 2;
       bigWord.style.fontSize = size + 'px';
     }

--- a/style.css
+++ b/style.css
@@ -270,7 +270,8 @@ main {
   border: 1px dashed var(--border);
   border-radius: 16px;
   padding: 16px;
-  min-height: 120px; /* ensure space but allow multi-line words */
+  height: 150px; /* keep area fixed so buttons don't move */
+  overflow: hidden;
 }
 
 .word .bigword {


### PR DESCRIPTION
## Summary
- Keep displayed word area at a fixed height to stop buttons from moving
- Scale word text down so long words fit within the fixed area

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a177b46b88832b9553ff1841b31777